### PR TITLE
Update plugins and tools to latest supported version

### DIFF
--- a/Centaurus.jsproj
+++ b/Centaurus.jsproj
@@ -78,7 +78,7 @@
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <TypeScriptToolsVersion>1.6</TypeScriptToolsVersion>
+    <TypeScriptToolsVersion>1.7</TypeScriptToolsVersion>
     <DefaultReferenceGroup>Implicit (Apache Cordova)</DefaultReferenceGroup>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">

--- a/hooks/after_platform_add/010_install_plugins.js
+++ b/hooks/after_platform_add/010_install_plugins.js
@@ -4,10 +4,10 @@
 
 // add your plugins to this list--either the identifier, the filesystem location or the URL
 var pluginlist = [
-    "https://github.com/driftyco/ionic-plugins-keyboard.git",
-	"https://github.com/EddyVerbruggen/SocialSharing-PhoneGap-Plugin.git",
-    "https://github.com/knowledgecode/WebSocket-for-Android.git",
+    "ionic-plugin-keyboard",
     "phonegap-plugin-barcodescanner",
+    "cordova-plugin-x-socialsharing",
+    "cordova-plugin-websocket",
     "cordova-plugin-console",
     "cordova-plugin-device",
     "cordova-plugin-globalization",

--- a/hooks/after_platform_add/010_install_plugins.js
+++ b/hooks/after_platform_add/010_install_plugins.js
@@ -7,12 +7,12 @@ var pluginlist = [
     "https://github.com/driftyco/ionic-plugins-keyboard.git",
 	"https://github.com/EddyVerbruggen/SocialSharing-PhoneGap-Plugin.git",
     "https://github.com/knowledgecode/WebSocket-for-Android.git",
-    "com.phonegap.plugins.barcodescanner",
-    "org.apache.cordova.console",
-    "org.apache.cordova.device",
-	"org.apache.cordova.file",
-    "org.apache.cordova.globalization",
-	"org.apache.cordova.inappbrowser"
+    "phonegap-plugin-barcodescanner",
+    "cordova-plugin-console",
+    "cordova-plugin-device",
+    "cordova-plugin-globalization",
+    "cordova-plugin-inappbrowser",
+    "cordova-plugin-file"
 ];
 
 // no need to configure below

--- a/package.json
+++ b/package.json
@@ -23,8 +23,6 @@
     "cordova-plugin-websocket",
     "cordova-plugin-x-socialsharing",
     "phonegap-plugin-barcodescanner",
-    "https://github.com/knowledgecode/WebSocket-for-Android.git",
-    "https://github.com/EddyVerbruggen/SocialSharing-PhoneGap-Plugin.git",
-    "https://github.com/driftyco/ionic-plugins-keyboard.git"
+    "ionic-plugin-keyboard"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -15,14 +15,14 @@
     "shelljs": "^0.3.0"
   },
   "cordovaPlugins": [
-    "org.apache.cordova.console",
-    "org.apache.cordova.device",
-    "org.apache.cordova.globalization",
-    "org.apache.cordova.inappbrowser",
-    "org.apache.cordova.file",
-    "com.phonegap.plugins.barcodescanner",
+    "cordova-plugin-console",
+    "cordova-plugin-device",
+    "cordova-plugin-globalization",
+    "cordova-plugin-inappbrowser",
+    "cordova-plugin-file",
     "cordova-plugin-websocket",
     "cordova-plugin-x-socialsharing",
+    "phonegap-plugin-barcodescanner",
     "https://github.com/knowledgecode/WebSocket-for-Android.git",
     "https://github.com/EddyVerbruggen/SocialSharing-PhoneGap-Plugin.git",
     "https://github.com/driftyco/ionic-plugins-keyboard.git"

--- a/taco.json
+++ b/taco.json
@@ -1,3 +1,3 @@
-﻿{
-	"cordova-cli": "4.3.0"
+{
+  "cordova-cli": "5.3.3"
 }


### PR DESCRIPTION
This will allow the addition of other platforms in the future (W10, WP8) and is the default for the TACO (VS Cordova) tools.

Cordova 5.4.1 isn't supported by TACO Update 4 and won't be supported in the upcoming Update 5 either.

**Update:** It seems there are some issues.

**Update 2:** Issues were because the platform config files in /plugins/ were still looking for the old plugins. Did succeed to run it on a W10M emulator and my device in the meantime with a small change. (comment out `cordova.plugins.Keyboard.hideKeyboardAccessoryBar(true);`in *app.js*). So I might create a PR in the near future to add W10M support.