### PR TITLE
clear cache in case we need to re-render page like when locale changes

### DIFF
--- a/www/templates/tab-transactions.html
+++ b/www/templates/tab-transactions.html
@@ -1,4 +1,4 @@
-<ion-view title="{{'tabs.trx.title' | translate}} (T)">
+<ion-view cache-view="false"  title="{{'tabs.trx.title' | translate}} (T)">
     <ion-content class="has-header">
         <ion-list ng-repeat="item in account.transactions">
             <div class="row item narrow" style="color:#20E000" ng-if="!item.debit">


### PR DESCRIPTION
clearing cache for the transaction view fixes the issue with changing locale.
But I am not sure if this is worth the minor inconvenience of re-starting the app after changing locale
for example, in case there is a long list of transactions.